### PR TITLE
Reduce minimum version to 7.4.0

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -32,7 +32,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '0.1.1',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '7.6.0-7.6.99',
+			'typo3' => '7.4.0-7.6.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
Added new minimum TYPO3-Version for people how aren't able to Update yet to TYPO3 7.6 Example for using DCE-Extension