### PR TITLE
Set autofocus on token field.

### DIFF
--- a/Resources/Private/Templates/LoginToken.html
+++ b/Resources/Private/Templates/LoginToken.html
@@ -6,7 +6,7 @@
 	<div class="form-group t3js-login-password-section" id="t3-login-password-section">
 		<div class="form-control-wrap">
 			<div class="form-control-holder">
-				<input type="password" id="t3-onetimesecret" name="oneTimeSecret" value="{token}" placeholder="Token" class="form-control input-login t3js-clearable t3js-login-password-field" required="required" data-rsa-encryption="t3-field-userident"/>
+				<input type="password" id="t3-onetimesecret" name="oneTimeSecret" value="{token}" placeholder="Token" class="form-control input-login t3js-clearable t3js-login-password-field" required="required" data-rsa-encryption="t3-field-userident" autofocus/>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
It is the only interactive element on the page. Setting focus on it when the
page is loaded improves UIX by not forcing the user to make an extra mouse click
on the input field.