### PR TITLE
[BUGFIX] - Set the generated secret directly in the userData array.

### DIFF
--- a/Classes/Auth/TokenAuthenticator.php
+++ b/Classes/Auth/TokenAuthenticator.php
@@ -140,6 +140,9 @@ class TokenAuthenticator implements SingletonInterface
             $this->user->userid_column . ' = ' . $this->userData[$this->user->userid_column],
             [$this->secretField => $secret]
         );
+
+        // update the value directly in userData for later use
+        $this->userData[$this->secretField] = $secret;
     }
 
     /**


### PR DESCRIPTION
To fill the form for a user without a secret stored in the DB `getData()` is unable to get you a valid token and the rendered QR is useless.

This patch saves a refresh of the form by directly setting the secret to the internal data array.